### PR TITLE
fix(android): request ACCESS_MEDIA_LOCATION for GPS data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ const tags = await Exify.read(uri)
 console.log(tags)
 ```
 
+> **Note:** On Android 10+, GPS data is redacted from `content://` URIs by default. The library automatically requests `ACCESS_MEDIA_LOCATION` at runtime to access unredacted location data. Your app must have media read access (`READ_MEDIA_IMAGES` or `READ_EXTERNAL_STORAGE`) granted first. If you're already using a library like [`expo-media-library`](https://docs.expo.dev/versions/latest/sdk/media-library/) that grants `ACCESS_MEDIA_LOCATION`, exify will use the existing grant.
+
 ### Writing Exif
 
 ```ts

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 </manifest>


### PR DESCRIPTION
## Summary

Fix GPS location data not showing on Android 10+ when reading from `content://` URIs. The OS redacts GPS EXIF data unless `ACCESS_MEDIA_LOCATION` is granted.

- Declare `ACCESS_MEDIA_LOCATION` in AndroidManifest.xml (auto-merged into app manifest)
- Auto-request the permission at runtime before reading `content://` URIs on API 29+
- Use `MediaStore.setRequireOriginal()` to access unredacted EXIF data
- Falls back gracefully if permission is denied or activity is unavailable

Closes #6

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

- Tested on Android 14 (Pixel 6 Pro) with `content://` URI
- Verified GPS tags are returned after permission grant
- Verified no crash if permission is denied
- Verified existing grant from `expo-media-library` is reused

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [x] I updated the documentation (if needed)