### PR TITLE
fix: validate URI scheme and improve error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ const tags = await Exify.read(uri)
 console.log(tags)
 ```
 
+> [!IMPORTANT]
+> The `uri` must include a scheme (e.g. `file://`, `ph://`, `content://`). Bare file paths like `/var/mobile/.../image.jpg` are not supported and will throw an error.
+
 > [!NOTE]
 > On Android 10+, GPS data is redacted from `content://` URIs by default. The library automatically requests `ACCESS_MEDIA_LOCATION` at runtime to access unredacted location data. Your app must have media read access (`READ_MEDIA_IMAGES` or `READ_EXTERNAL_STORAGE`) granted first.
 > If you're already using a library like [`expo-media-library`](https://docs.expo.dev/versions/latest/sdk/media-library/) that grants `ACCESS_MEDIA_LOCATION`, exify will use the existing grant.

--- a/android/src/main/java/com/lodev09/exify/ExifyModule.kt
+++ b/android/src/main/java/com/lodev09/exify/ExifyModule.kt
@@ -34,8 +34,8 @@ class ExifyModule(
     val scheme = photoUri.scheme
 
     if (scheme == null) {
-      RNLog.w(context, "Exify: Invalid URI: $uri")
-      promise.reject(ERROR_TAG, "Invalid URI: $uri")
+      RNLog.w(context, "Exify: URI must include a scheme (e.g. file://): $uri")
+      promise.reject(ERROR_TAG, "URI must include a scheme (e.g. file://): $uri")
       return
     }
 
@@ -108,6 +108,13 @@ class ExifyModule(
     promise: Promise,
   ) {
     val photoUri = Uri.parse(uri)
+
+    if (photoUri.scheme == null) {
+      RNLog.w(context, "Exify: URI must include a scheme (e.g. file://): $uri")
+      promise.reject(ERROR_TAG, "URI must include a scheme (e.g. file://): $uri")
+      return
+    }
+
     val params = Arguments.createMap()
 
     try {

--- a/ios/Exify.mm
+++ b/ios/Exify.mm
@@ -226,6 +226,16 @@ static NSDictionary *updateMetadata(NSURL *url, NSDictionary *tags) {
                                  resolve(tags);
                                }];
   } else {
+    if ([uri hasPrefix:@"/"] || ![uri containsString:@"://"]) {
+      RCTLogWarn(@"Exify: URI must include a scheme (e.g. file://): %@", uri);
+      reject(@"Error",
+             [NSString stringWithFormat:@"URI must include a scheme (e.g. "
+                                        @"file://): %@",
+                                        uri],
+             nil);
+      return;
+    }
+
     NSURL *url = [NSURL URLWithString:uri];
     if (!url) {
       RCTLogWarn(@"Exify: Invalid URI: %@", uri);
@@ -317,6 +327,16 @@ static NSDictionary *updateMetadata(NSURL *url, NSDictionary *tags) {
                               });
                             }];
   } else {
+    if ([uri hasPrefix:@"/"] || ![uri containsString:@"://"]) {
+      RCTLogWarn(@"Exify: URI must include a scheme (e.g. file://): %@", uri);
+      reject(@"Error",
+             [NSString stringWithFormat:@"URI must include a scheme (e.g. "
+                                        @"file://): %@",
+                                        uri],
+             nil);
+      return;
+    }
+
     NSURL *url = [NSURL URLWithString:uri];
     if (!url) {
       reject(@"Error", @"Invalid URL", nil);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,19 @@
 import Exify from './NativeExify';
 import type { ExifTags, ExifyWriteResult } from './types';
 
+/**
+ * Read Exif metadata from an image.
+ * @param uri Image URI with a scheme (e.g. `file://`, `ph://`, `content://`). Bare file paths are not supported.
+ */
 export function read(uri: string): Promise<ExifTags | null> {
   return Exify.read(uri) as Promise<ExifTags | null>;
 }
 
+/**
+ * Write Exif metadata into an image.
+ * @param uri Image URI with a scheme (e.g. `file://`, `ph://`, `content://`). Bare file paths are not supported.
+ * @param tags Exif tags to write.
+ */
 export function write(uri: string, tags: ExifTags): Promise<ExifyWriteResult> {
   return Exify.write(uri, tags as Object) as Promise<ExifyWriteResult>;
 }


### PR DESCRIPTION
## Summary

Reject bare file paths (e.g. `/var/mobile/...`) with a clear error message indicating that a scheme (`file://`, `ph://`, `content://`) is required.

- iOS: add scheme validation in `read` and `write` methods
- Android: add scheme validation in `write`, improve `read` error message
- Add JSDoc to `read()` and `write()`
- Update README with URI format note

Closes #9

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Test Plan

Pass a bare file path (e.g. `/var/mobile/.../image.jpg`) to `read()` and `write()` — should reject with a descriptive error.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I updated the documentation (if needed)