### PR TITLE
fix: route iOS write tags to correct EXIF dictionaries

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -44,7 +44,14 @@ export default function App() {
       GPSLongitude: lng,
       GPSTimeStamp: '10:10:10',
       GPSDateStamp: '2024:10:10',
+      GPSDOP: 5.0,
+      GPSImgDirection: 180.5,
+      GPSImgDirectionRef: 'T',
       UserComment: 'Exif updated via @lodev09/react-native-exify',
+      Make: 'Exify',
+      Model: 'ExifyCamera',
+      Software: 'react-native-exify',
+      DateTime: '2024:10:10 10:10:10',
     };
 
     console.log('writeExif:', json(tags));

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,7 @@ export interface ExifTags {
   SubjectDistanceRange?: number;
   XResolution?: number;
   Software?: string;
+  HostComputer?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Fixes #11. iOS `write` was putting all tags into `kCGImagePropertyExifDictionary`, causing TIFF tags (`Make`, `Model`, `Software`, `DateTime`) and most GPS tags (`GPSDOP`, `GPSImgDirection`, `GPSImgDirectionRef`) to be silently dropped.

Tags are now routed to the correct sub-dictionary:
- TIFF keys → `kCGImagePropertyTIFFDictionary`
- GPS keys → `kCGImagePropertyGPSDictionary` (generic, not just 5 hardcoded)
- Everything else → `kCGImagePropertyExifDictionary`

Also adds `HostComputer` to `ExifTags` type.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Took photo in example app, wrote tags (Make, Model, Software, DateTime, GPSDOP, GPSImgDirection, GPSImgDirectionRef), saved to media library, read back — all tags preserved.

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I updated the documentation (if needed)