### PR TITLE
fix: respect explicit GPS ref values during write

### DIFF
--- a/android/src/main/java/com/lodev09/exify/ExifyUtils.kt
+++ b/android/src/main/java/com/lodev09/exify/ExifyUtils.kt
@@ -46,4 +46,19 @@ object ExifyUtils {
 
     return tags
   }
+
+  @JvmStatic
+  fun decimalToDms(decimal: Double): String {
+    val degrees = decimal.toInt()
+    val minutesDecimal = (decimal - degrees) * 60
+    val minutes = minutesDecimal.toInt()
+    val seconds = ((minutesDecimal - minutes) * 60 * 10000).toLong()
+    return "$degrees/1,$minutes/1,$seconds/10000"
+  }
+
+  @JvmStatic
+  fun decimalToRational(value: Double): String {
+    val numerator = (value * 10000).toLong()
+    return "$numerator/10000"
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #12. `write()` now respects explicit `GPSLatitudeRef`, `GPSLongitudeRef`, and `GPSAltitudeRef` values when provided alongside coordinates, instead of always deriving direction from the sign of the coordinate value.

This fixes the read→write round-trip where `GPSLongitudeRef: 'W'` with a positive longitude would be incorrectly overwritten to `'E'`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Long-press library button in example app to run read→write→verify round-trip
- Tested on iOS with a photo containing western longitude — `GPSLongitudeRef: 'W'` preserved correctly

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I updated the documentation (if needed)