### PR TITLE
fix(android): use rational format for GPS double tags on write

### DIFF
--- a/android/src/main/java/com/lodev09/exify/ExifyModule.kt
+++ b/android/src/main/java/com/lodev09/exify/ExifyModule.kt
@@ -133,7 +133,14 @@ class ExifyModule(
 
             ReadableType.Number -> {
               when (valType) {
-                "double" -> exif.setAttribute(tag, tags.getDouble(tag).toBigDecimal().toPlainString())
+                "double" -> {
+                  val value = tags.getDouble(tag)
+                  if (tag.startsWith("GPS")) {
+                    exif.setAttribute(tag, ExifyUtils.decimalToRational(value))
+                  } else {
+                    exif.setAttribute(tag, value.toBigDecimal().toPlainString())
+                  }
+                }
                 else -> exif.setAttribute(tag, tags.getDouble(tag).toInt().toString())
               }
             }


### PR DESCRIPTION
## Summary

GPS double tags (GPSDOP, GPSImgDirection, GPSSpeed, GPSTrack, GPSDestBearing, etc.) were not persisted on Android. ExifInterface expects GPS rational values in `numerator/denominator` format, but we were writing plain decimal strings which were silently dropped on `saveAttributes()`.

Fixes #29 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Write GPSDOP and other GPS double tags via `Exify.write()`, then `Exify.read()` — values now persist

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I updated the documentation (if needed)