### PR TITLE
fix(android): use double type for GPSHPositioningError tag

### DIFF
--- a/android/src/main/java/com/lodev09/exify/ExifyTags.kt
+++ b/android/src/main/java/com/lodev09/exify/ExifyTags.kt
@@ -112,7 +112,7 @@ val EXIFY_TAGS =
     arrayOf("double", ExifInterface.TAG_GPS_DEST_LONGITUDE),
     arrayOf("string", ExifInterface.TAG_GPS_DEST_LONGITUDE_REF),
     arrayOf("int", ExifInterface.TAG_GPS_DIFFERENTIAL),
-    arrayOf("string", ExifInterface.TAG_GPS_H_POSITIONING_ERROR),
+    arrayOf("double", ExifInterface.TAG_GPS_H_POSITIONING_ERROR),
     arrayOf("double", ExifInterface.TAG_GPS_IMG_DIRECTION),
     arrayOf("string", ExifInterface.TAG_GPS_IMG_DIRECTION_REF),
     arrayOf("string", ExifInterface.TAG_GPS_LATITUDE_REF),

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,7 +51,7 @@ export default function App() {
       GPSTimeStamp: '10:10:10',
       GPSDateStamp: '2024:10:10',
       GPSDOP: 5.0,
-      GPSHPositioningError: '10.0',
+      GPSHPositioningError: 10.0,
       GPSImgDirection: 180.5,
       GPSImgDirectionRef: 'T',
       UserComment: 'Exif updated via @lodev09/react-native-exify',

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface ExifTags {
   GPSDifferential?: number;
   GPSDestLatitudeRef?: string;
   GPSDestDistanceRef?: string;
-  GPSHPositioningError?: string;
+  GPSHPositioningError?: number;
   GPSDestDistance?: number;
   GPSDestBearing?: number;
   GPSDateStamp?: string;


### PR DESCRIPTION
## Summary

Android's `ExifInterface` expects `IFD_FORMAT_URATIONAL` for `GPSHPositioningError`. The tag was typed as `"string"` in `ExifyTags.kt`, causing `setAttribute` to silently fail on write. Changed to `"double"` so the value goes through `decimalToRational()` — matching the expected rational format.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Verified on both iOS and Android that `GPSHPositioningError` persists after write and reads back correctly.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I updated the documentation (if needed)